### PR TITLE
Allow specifying ref patterns to fetch

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -726,6 +726,7 @@ module Git
 
     def fetch(remote, opts)
       arr_opts = [remote]
+      arr_opts << opts[:refs] if opts[:refs]
       arr_opts << '--tags' if opts[:t] || opts[:tags]
       arr_opts << '--prune' if opts[:p] || opts[:prune]
       arr_opts << '--unshallow' if opts[:unshallow]


### PR DESCRIPTION
Mostly useful when fetching from a specific URL.